### PR TITLE
Update row count

### DIFF
--- a/app_gen_script.gs
+++ b/app_gen_script.gs
@@ -34,7 +34,7 @@ function generateForAllRecords(settings){
     } else {
       var len = data.length
       }
-  for (i=1; i<len; i++){
+  for (i=0; i<len; i++){
     var doc_name = data[i].gs_level_applied_to + " - " + data[i].full_name + " Application"
     if (!DriveApp.getFolderById(settings.TARGET_FOLDER).getFilesByName(doc_name).hasNext()){
       generateForSingleRecord(data[i], doc_name, settings)


### PR DESCRIPTION
The original script assumed that the row after the header needed to be skipped which resulted in the script skipping the first entry after the header in the sheet. This was no longer necessary so initialized the count with 0 instead of 1.